### PR TITLE
Feature/metabuilder

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,23 @@
 import Image from 'next/image'
+import { Octokit } from "octokit";
+import github_logo from 'src/img/github-mark-white.svg'
+const contributors = await getContributorsWeb()
+var metavar3 = []
+async function getContributorsWeb() {
+    const token = process.env.GITHUB_TOKEN
+    const octokit = new Octokit({
+        auth: token
+    })
+
+    const response = await octokit.request('GET /repos/{owner}/{repo}/contributors', {
+        owner: "negative-light-media",
+        repo: 'www.negative-light.com',
+    })
+
+
+    return response.data
+}
+
 function Home(){
 
 
@@ -11,11 +30,25 @@ function Home(){
 <meta name="description" content="Official page for Negative Light Media "/>
 <meta name="keywords" content="NLM, media, negative-light, Negative_light, Minecraft, Youtube, Programming, Mods, modding"/>
 <meta name="author" content="Negative-light"/>
-<meta name="contributors" content="sourabh1111111, crazysmile11012"/>
 <meta name="publisher" content="Negative-light-media"/>
 <title>negative-light.com</title>
 </head>
 <body>
+<div className="metabuilder">
+			<table>
+			<tbody>
+			{contributors.map(contributor => ((
+			
+			
+			<tr key={metavar3 = metavar3 + contributor.login + ", "}></tr>
+			
+		
+			
+			)))}
+			</tbody>
+			</table>
+			</div>
+			<meta name="contributors" content={metavar3} />
 <center>
   <header>
     <h2><u>Negative Light Media - About</u></h2>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import { Octokit } from "octokit";
 import github_logo from 'src/img/github-mark-white.svg'
 const contributors = await getContributorsWeb()
-var metavar3 = []
+
 async function getContributorsWeb() {
     const token = process.env.GITHUB_TOKEN
     const octokit = new Octokit({
@@ -20,7 +20,7 @@ async function getContributorsWeb() {
 
 function Home(){
 
-
+var metavar3 = []
   return (
   <>
   <head>
@@ -42,7 +42,6 @@ function Home(){
 			
 			<tr key={metavar3 = metavar3 + contributor.login + ", "}></tr>
 			
-		
 			
 			)))}
 			</tbody>

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -24,20 +24,40 @@ async function Home() {
     //const data = contributorTable.match(/<sub><b>(.*)<\/b>/g)
     const contributors = await getContributorsWeb()
     const profile_size = 128
+	var metavar = []
     return (
         <>
             <head>
+			
+			
                 <meta name="viewport" content="width-device-width, initial-scale-1" />
                 <meta charSet="UTF-8" />
                 <link rel="icon" type="image/x-icon" href="img/favicon.png" />
                 <meta name="description" content="Contributors List for Negative Light Media " />
+				
                 <meta name="keywords" content="NLM, media, negative-light, Negative_light, Minecraft, Youtube, Programming, Mods, modding" />
                 <meta name="author" content="Negative-light" />
-                <meta name="contributors" content="sourabh1111111, crazysmile11012" />
+                
                 <meta name="publisher" content="Negative-light-media" />
                 <title>negative-light.com</title>
+				
             </head>
             <body>
+			<div className="metabuilder">
+			<table>
+			<tbody>
+			{contributors.map(contributor => ((
+			
+			
+			<tr key={metavar = metavar + contributor.login + ", "}></tr>
+			
+		
+			
+			)))}
+			</tbody>
+			</table>
+			</div>
+			<meta name="contributors" content={metavar} />
                 <center>
                     <header>
                         <h2><u>negative-light website Contributors</u></h2>
@@ -52,6 +72,7 @@ async function Home() {
                             <tbody>
                             {contributors.map(contributor => ((
                                 <tr key={contributor.login}>
+									
                                     <td align="center">
                                         <Image src={contributor.avatar_url} width={profile_size} height={profile_size} alt={contributor.login + "Profile Picture"}></Image>
                                     </td>
@@ -61,6 +82,7 @@ async function Home() {
                                         <a href={contributor.html_url}>
                                             <Image src={github_logo} width={profile_size} height={profile_size} alt={contributor.login + "Profile Github"}></Image>
                                         </a>
+										
                                     </td>
                                 </tr>
                             )))}
@@ -70,6 +92,8 @@ async function Home() {
                     </div>
                     <footer>
                         <article>
+										
+
                             <h4>This website is under construction</h4>
 							<h4><a href="/">Back to Homepage</a></h4>
                             

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,25 @@ import Image from 'next/image'
 import discord from 'src/img/discord.svg'
 import nlm from 'src/img/favicon.png'
 import linktree from'src/img/linktree.svg'
+import { Octokit } from "octokit";
+import github_logo from 'src/img/github-mark-white.svg'
+const contributors = await getContributorsWeb()
+var metavar2 = []
+async function getContributorsWeb() {
+    const token = process.env.GITHUB_TOKEN
+    const octokit = new Octokit({
+        auth: token
+    })
+
+    const response = await octokit.request('GET /repos/{owner}/{repo}/contributors', {
+        owner: "negative-light-media",
+        repo: 'www.negative-light.com',
+    })
+
+
+    return response.data
+}
+
 function Home(){
 
   return (
@@ -14,12 +33,26 @@ function Home(){
 <meta name="description" content="Official page for Negative Light Media "></meta>
 <meta name="keywords" content="NLM, media, negative-light, Negative_light, Minecraft, Youtube, Programming, Mods, modding"></meta>
 <meta name="author" content="Negative-light"></meta>
-<meta name="contributors" content="sourabh1111111, crazysmile11012"></meta>
 <meta name="publisher" content="Negative-light-media"></meta>
 <title>negative-light.com</title>
 
 </head>
 <body>
+<div className="metabuilder">
+			<table>
+			<tbody>
+			{contributors.map(contributor => ((
+			
+			
+			<tr key={metavar2 = metavar2 + contributor.login + ", "}></tr>
+			
+		
+			
+			)))}
+			</tbody>
+			</table>
+			</div>
+			<meta name="contributors" content={metavar2} />
 <center>
   <header>
     <h2><u>Negative Light</u></h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import linktree from'src/img/linktree.svg'
 import { Octokit } from "octokit";
 import github_logo from 'src/img/github-mark-white.svg'
 const contributors = await getContributorsWeb()
-var metavar2 = []
 async function getContributorsWeb() {
     const token = process.env.GITHUB_TOKEN
     const octokit = new Octokit({
@@ -22,6 +21,7 @@ async function getContributorsWeb() {
 }
 
 function Home(){
+var metavar2 = []
 
   return (
   <>


### PR DESCRIPTION
this solves issue: #54 
makes metadata automatically update from latest api data from github
# what it does
- pulls data from repo stats
- makes a client side for loop for each datapoint & appends into a list
- updates the meta with the compiled list
*notes*
- can be used for most metadata, provided you have a typescript api that is clientside 
- runs fully on the hosts computer
- it will not do the dishes for you (had to put something silly in here :D)